### PR TITLE
Tec 44: Khalti integration into spree_gateways_nepal

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_gateways_nepal.js
+++ b/app/assets/javascripts/spree/frontend/spree_gateways_nepal.js
@@ -1,0 +1,32 @@
+//= require spree/frontend
+
+SpreeGatewaysNepal = {
+  updateSaveAndContinueVisibility: function() {
+    if (this.isButtonHidden()) {
+      $(this).trigger('hideSaveAndContinue')
+    } else {
+      $(this).trigger('showSaveAndContinue')
+    }
+  },
+  isButtonHidden: function () {
+    paymentMethod = this.checkedPaymentMethod();
+    return (!$('#use_existing_card_yes:checked').length && SpreeGatewaysNepal.paymentMethodID && paymentMethod.val() == SpreeGatewaysNepal.paymentMethodID);
+  },
+  checkedPaymentMethod: function() {
+    return $('div[data-hook="checkout_payment_step"] input[type="radio"][name="order[payments_attributes][][payment_method_id]"]:checked');
+  },
+  hideSaveAndContinue: function() {
+    $("#checkout_form_payment [data-hook=buttons]").hide();
+  },
+  showSaveAndContinue: function() {
+    $("#checkout_form_payment [data-hook=buttons]").show();
+  }
+}
+
+$(document).ready(function() {
+  SpreeGatewaysNepal.updateSaveAndContinueVisibility();
+  paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
+    // debugger
+    SpreeGatewaysNepal.updateSaveAndContinueVisibility();
+  });
+})

--- a/app/assets/javascripts/spree/frontend/spree_gateways_nepal.js
+++ b/app/assets/javascripts/spree/frontend/spree_gateways_nepal.js
@@ -26,7 +26,6 @@ SpreeGatewaysNepal = {
 $(document).ready(function() {
   SpreeGatewaysNepal.updateSaveAndContinueVisibility();
   paymentMethods = $('div[data-hook="checkout_payment_step"] input[type="radio"]').click(function (e) {
-    // debugger
     SpreeGatewaysNepal.updateSaveAndContinueVisibility();
   });
 })

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -23,6 +23,10 @@ module Spree
         response = https.request(request)
 
         if response_code.eql?(200)
+          responseJSON = JSON.parse(response.body)
+
+          # Update the payment source with the response then complete
+          current_payment.source.update!(khalti_response_attributes(responseJSON))
           current_payment.complete!
 
           unless current_order.next
@@ -80,6 +84,30 @@ module Spree
       end
 
       payment
+    end
+
+    def khalti_response_attributes(responseJSON)
+      update_attributes = {
+        khalti_payment_token_id: responseJSON['idx'],
+        khalti_payment_type_id: responseJSON['type']['idx'],
+        khalti_payment_type_name: responseJSON['type']['name'],
+        payment_state_id: responseJSON['state']['idx'],
+        payment_state_name: responseJSON['state']['name'],
+        payment_state_template: responseJSON['state']['template'],
+        amount: responseJSON['amount'],
+        fee_amount: responseJSON['fee_amount'],
+        refunded: responseJSON['refunded'],
+        created_on: responseJSON['created_on'],
+        ebanker: responseJSON['ebanker'],
+        khalti_user_id: responseJSON['user']['idx'],
+        khalti_user_name: responseJSON['user']['name'],
+        khalti_user_email: responseJSON['user']['email'],
+        khalti_user_mobile: responseJSON['user']['mobile'],
+        khalti_merchant_id: responseJSON['merchant']['idx'],
+        khalti_merchant_name: responseJSON['merchant']['name'],
+        khalti_merchant_mobile: responseJSON['merchant']['mobile'],
+        khalti_merchant_email: responseJSON['merchant']['email']
+      }
     end
 
   end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -56,7 +56,7 @@ module Spree
         productIdentity: current_order.number,
         productName: current_order.number,
         productUrl: "#{current_store.url}/orders/#{current_order.number}",
-        paymnetPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
+        paymentPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
         checkoutAmount: (current_order.total) * 100 #Converting to Pais
       }
 
@@ -78,6 +78,7 @@ module Spree
         state: 'checkout',
         source: Spree::KhaltiPaymentSource.create
       )
+
       unless payment.save!
         flash[:error] = payment.errors.full_messages.join("\n")
         redirect_to checkout_state_path(current_order.state) and return

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -5,24 +5,42 @@ module Spree
     skip_before_action :verify_authenticity_token
 
     def payment
-      @payment_method = PaymentMethod.find(params[:payment_method_id])
+      payment_method = PaymentMethod.find(params[:payment_method_id])
 
-      headers = {
-        Authorization: "Key #{@payment_method.preferences[:test_secret_key]}"
-      }
-      uri = URI.parse('https://khalti.com/api/v2/payment/verify/')
-      https = Net::HTTP.new(uri.host, uri.port)
-      https.use_ssl = true
-      request = Net::HTTP::Post.new(uri.request_uri, headers)
-      request.set_form_data('token' => params[:payload][:token], 'amount' => params[:payload][:amount].to_f)
-      response = https.request(request)
-      render json: {message: response.message, code: response.code}
+      order = current_order || raise(ActiveRecord::RecordNotFound)
+      
+      begin
+        # API call to khalti
+        headers = {
+          Authorization: "Key #{payment_method.preferences[:test_secret_key]}"
+        }
+        uri = URI.parse('https://khalti.com/api/v2/payment/verify/')
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+        request = Net::HTTP::Post.new(uri.request_uri, headers)
+        request.set_form_data('token' => params[:payload][:token], 'amount' => params[:payload][:amount].to_f)
+        response = https.request(request)
+
+        if response_code.eql?(200)
+
+          payment_success(payment_method)
+          # render json: {message: response.message, code: response.code}
+
+          # redirect_to response.redirect_uri if payment_success(payment_method)
+        else
+          flash[:error] = Spree.t('flash.generic_error', scope: 'khalti', reasons: 'Server verification with khalti failed')
+          # redirect_to checkout_state_path(:payment)
+        end
+      rescue SocketError
+        flash[:error] = Spree.t('flash.connection_failed', scope: 'khalti')
+        redirect_to checkout_state_path(:payment)
+      end
+
     end
 
     # To be used when configurations need to be fetched from the UI
     def khalti_payment_config
       @payment_method = PaymentMethod.find(params[:payment_method_id])
-
       config = {
         publicKey: @payment_method.preferences[:test_public_key],
         productIdentity: current_order.number,
@@ -34,5 +52,37 @@ module Spree
 
       render json: {config: config}, status: :ok
     end
+
+    def provider
+      payment_method.provider
+    end
+
+    def completion_route(order)
+      order_path(order)
+    end
+
+    def payment_success(payment_method)
+      payment = current_order.payments.build(
+        payment_method_id: payment_method.id,
+        amount: current_order.total,
+        state: 'checkout',
+        source: Spree::CreditCard.first
+      )
+      unless payment.save
+        flash[:error] = payment.errors.full_messages.join("\n")
+        redirect_to checkout_state_path(current_order.state) and return
+      end
+      binding.pry
+      # unless current_order.next
+
+      #   flash[:error] = @order.errors.full_messages.join("\n")
+      #   redirect_to checkout_state_path(current_order.state) and return
+      # end
+      # binding.pry
+      payment.pend!
+    end
+
   end
+
+
 end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -1,5 +1,3 @@
-require 'uri'
-require 'net/http'
 module Spree
   class KhaltiController < StoreController
     skip_before_action :verify_authenticity_token
@@ -82,7 +80,6 @@ module Spree
       end
 
       payment
-
     end
 
   end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -13,7 +13,7 @@ module Spree
       begin
         # API call to khalti
         headers = {
-          Authorization: "Key #{payment_method.preferences[:test_secret_key]}"
+          Authorization: "Key #{payment_method.preferences[:test_mode] ? payment_method.preferences[:test_secret_key] :  payment_method.preferences[:live_secret_key] }"
         }
         uri = URI.parse('https://khalti.com/api/v2/payment/verify/')
         https = Net::HTTP.new(uri.host, uri.port)
@@ -61,7 +61,7 @@ module Spree
         productName: current_order.number,
         productUrl: "#{current_store.url}/orders/#{current_order.number}",
         paymentPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
-        checkoutAmount: (current_order.total) * 100 #Converting to Pais
+        checkoutAmount: (current_order.total) * paisa_rate #Converting to Pais
       }
 
       render json: {config: config}, status: :ok

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -1,0 +1,38 @@
+require 'uri'
+require 'net/http'
+module Spree
+  class KhaltiController < StoreController
+    skip_before_action :verify_authenticity_token
+
+    def payment
+      headers = {
+        Authorization: 'Key test_secret_key_3bab07ad22d741d8b1e9cae0e7040a33'
+      }
+      uri = URI.parse('https://khalti.com/api/v2/payment/verify/')
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      request = Net::HTTP::Post.new(uri.request_uri, headers)
+      request.set_form_data('token' => params[:token], 'amount' => params[:amount].to_f)
+      response = https.request(request)
+
+      render json: {message: 'Successfully transfered fund from Khalti'}, status: :ok
+    end
+
+    def khalti_payment_config
+      config = {
+        publicKey: "",
+        productIdentity: current_order.number,
+        productName: current_order.products.first.name,
+        productUrl: "http://hello.com",
+        paymnetPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
+        checkoutAmount: (current_order.total) * 100 #Converting to Paisa
+      }
+      respond_to do |format|
+        format.html {  }
+        format.json {render json: config, status: :ok}
+      end
+      # render json: config, status: :ok
+    end
+
+  end
+end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -5,17 +5,18 @@ module Spree
     skip_before_action :verify_authenticity_token
 
     def payment
+      @payment_method = PaymentMethod.find(params[:payment_method_id])
+
       headers = {
-        Authorization: 'Key test_secret_key_3bab07ad22d741d8b1e9cae0e7040a33'
+        Authorization: "Key #{@payment_method.preferences[:test_secret_key]}"
       }
       uri = URI.parse('https://khalti.com/api/v2/payment/verify/')
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri, headers)
-      request.set_form_data('token' => params[:token], 'amount' => params[:amount].to_f)
+      request.set_form_data('token' => params[:payload][:token], 'amount' => params[:payload][:amount].to_f)
       response = https.request(request)
-
-      render json: {message: 'Successfully transfered fund from Khalti'}, status: :ok
+      render json: {message: response.message, code: response.code}
     end
 
     def khalti_payment_config

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -19,6 +19,20 @@ module Spree
       render json: {message: response.message, code: response.code}
     end
 
+    # To be used when configurations need to be fetched from the UI
+    def khalti_payment_config
+      @payment_method = PaymentMethod.find(params[:payment_method_id])
 
+      config = {
+        publicKey: @payment_method.preferences[:test_public_key],
+        productIdentity: current_order.number,
+        productName: current_order.number,
+        productUrl: "#{current_store.url}/orders/#{current_order.number}",
+        paymnetPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
+        checkoutAmount: (current_order.total) * 100 #Converting to Pais
+      }
+
+      render json: {config: config}, status: :ok
+    end
   end
 end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -19,21 +19,6 @@ module Spree
       render json: {message: response.message, code: response.code}
     end
 
-    def khalti_payment_config
-      config = {
-        publicKey: "",
-        productIdentity: current_order.number,
-        productName: current_order.products.first.name,
-        productUrl: "http://hello.com",
-        paymnetPreference: ["MOBILE_BANKING", "KHALTI", "EBANKING","CONNECT_IPS","SCT"],
-        checkoutAmount: (current_order.total) * 100 #Converting to Paisa
-      }
-      respond_to do |format|
-        format.html {  }
-        format.json {render json: config, status: :ok}
-      end
-      # render json: config, status: :ok
-    end
 
   end
 end

--- a/app/controllers/spree/khalti_controller.rb
+++ b/app/controllers/spree/khalti_controller.rb
@@ -26,7 +26,7 @@ module Spree
           responseJSON = JSON.parse(response.body)
 
           # Update the payment source with the response then complete
-          current_payment.source.update!(khalti_response_attributes(responseJSON))
+          current_payment.source.update!(khalti_response_attributes(responseJSON).merge({payment_method_id: payment_method.id, user_id: current_order.user.id}))
           current_payment.complete!
 
           unless current_order.next

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -8,20 +8,20 @@ class Spree::Gateway::Khalti < Spree::Gateway
   preference :live_public_key, :string
   preference :live_secret_key, :string
 
+  def auto_capture?
+    true
+  end
+
   def provider_class
     Spree::Gateway::Khalti
   end
+
   def payment_source_class
-    Spree::PaymentMethod
+    Spree::CreditCard
   end
 
   def method_type
     'khalti'
   end
 
-  def purchase(amount, transaction_details, options = {})
-    # Have to write the code to verify the transaction here
-    # and send the success response to the frontend here
-    ActiveMerchant::Billing::Response.new(true, 'success', {}, {})
-  end
 end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,6 +1,6 @@
 class Spree::Gateway::Khalti < Spree::Gateway
   attr_accessor :server, :test_mode
-
+  preference :server
   preference :test_mode, :boolean, default: true
   preference :test_public_key, :string
   preference :test_secret_key, :string

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,7 +1,6 @@
 class Spree::Gateway::Khalti < Spree::Gateway
   attr_accessor :server, :test_mode
 
-
   preference :server,:string, default: 'test'
   preference :test_mode, :boolean, default: true
   preference :test_public_key, :string
@@ -13,7 +12,7 @@ class Spree::Gateway::Khalti < Spree::Gateway
     Spree::Gateway::Khalti
   end
   def payment_source_class
-    Spree::CreditCard
+    Spree::PaymentMethod
   end
 
   def method_type

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,7 +1,6 @@
 class Spree::Gateway::Khalti < Spree::Gateway
   attr_accessor :server, :test_mode
 
-  preference :server,:string, default: 'test'
   preference :test_mode, :boolean, default: true
   preference :test_public_key, :string
   preference :test_secret_key, :string

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,0 +1,16 @@
+class Spree::Gateway::Khalti < Spree::Gateway
+  def provider_class
+    Spree::Gateway::Khalti
+  end
+  def payment_source_class
+    Spree::CreditCard
+  end
+
+  def method_type
+    'khalti'
+  end
+
+  def purchase(amount, transaction_details, options = {})
+    ActiveMerchant::Billing::Response.new(true, 'success', {}, {})
+  end
+end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -29,4 +29,8 @@ class Spree::Gateway::Khalti < Spree::Gateway
     'khalti'
   end
 
+  def paisa_rate
+    100
+  end
+
 end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,7 +1,5 @@
 class Spree::Gateway::Khalti < Spree::Gateway
-  attr_accessor :server, :test_mode
 
-  preference :server,:string, default: 'test'
   preference :test_mode, :boolean, default: true
   preference :test_public_key, :string
   preference :test_secret_key, :string

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -22,8 +22,7 @@ class Spree::Gateway::Khalti < Spree::Gateway
 
   def purchase(amount, source, options = {})
     Class.new do
-      def success?; tru
-        e; end
+      def success?; true; end
       def authorization; nil; end
     end.new
   end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -4,6 +4,10 @@ class Spree::Gateway::Khalti < Spree::Gateway
 
   preference :server,:string, default: 'test'
   preference :test_mode, :boolean, default: true
+  preference :test_public_key, :string
+  preference :test_secret_key, :string
+  preference :live_public_key, :string
+  preference :live_secret_key, :string
 
   def provider_class
     Spree::Gateway::Khalti
@@ -17,7 +21,8 @@ class Spree::Gateway::Khalti < Spree::Gateway
   end
 
   def purchase(amount, transaction_details, options = {})
-    binding.pry
+    # Have to write the code to verify the transaction here
+    # and send the success response to the frontend here
     ActiveMerchant::Billing::Response.new(true, 'success', {}, {})
   end
 end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,4 +1,10 @@
 class Spree::Gateway::Khalti < Spree::Gateway
+  attr_accessor :server, :test_mode
+
+
+  preference :server,:string, default: 'test'
+  preference :test_mode, :boolean, default: true
+
   def provider_class
     Spree::Gateway::Khalti
   end
@@ -11,6 +17,7 @@ class Spree::Gateway::Khalti < Spree::Gateway
   end
 
   def purchase(amount, transaction_details, options = {})
+    binding.pry
     ActiveMerchant::Billing::Response.new(true, 'success', {}, {})
   end
 end

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -17,7 +17,15 @@ class Spree::Gateway::Khalti < Spree::Gateway
   end
 
   def payment_source_class
-    Spree::CreditCard
+    Spree::KhaltiPaymentSource
+  end
+
+  def purchase(amount, source, options = {})
+    Class.new do
+      def success?; tru
+        e; end
+      def authorization; nil; end
+    end.new
   end
 
   def method_type

--- a/app/models/spree/gateway/khalti.rb
+++ b/app/models/spree/gateway/khalti.rb
@@ -1,6 +1,7 @@
 class Spree::Gateway::Khalti < Spree::Gateway
   attr_accessor :server, :test_mode
-  preference :server
+
+  preference :server,:string, default: 'test'
   preference :test_mode, :boolean, default: true
   preference :test_public_key, :string
   preference :test_secret_key, :string

--- a/app/models/spree/khalti_payment_source.rb
+++ b/app/models/spree/khalti_payment_source.rb
@@ -1,0 +1,23 @@
+module Spree
+  class Spree::KhaltiPaymentSource < Spree::Base
+    belongs_to :payment_method
+    has_many :payments, as: :source
+
+    def actions
+      []
+    end
+
+    def transaction_id
+      payment_id
+    end
+
+    def method_type
+      'khalti_payment_source'
+    end
+
+    def name
+      'Khalti Wallet'
+    end
+
+  end
+end

--- a/app/models/spree/khalti_payment_source.rb
+++ b/app/models/spree/khalti_payment_source.rb
@@ -1,6 +1,7 @@
 module Spree
   class Spree::KhaltiPaymentSource < Spree::Base
     belongs_to :payment_method
+
     has_many :payments, as: :source
 
     def actions

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,4 +1,5 @@
 <a id="payment-button-khalti" href="#">Pay with Khalti</a>
+<% binding.pry %>
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', function () {
@@ -6,14 +7,12 @@
   })
 
   var config = {
-    // replace this key with yours
     publicKey: "<%= Spree::Gateway::Khalti.first.preferences[:test_public_key] %>",
-    productIdentity:"<%= current_order.name %>",
-    productName: "<%= current_order.products.first.name %>",
-    productUrl: "<%= 'https://bazarnp.com/products/' + current_order.products.first.slug%>",
+    productIdentity:"<%= current_order.number %>",
+    productName: "<%= current_order.number %>",
+    productUrl: "<%= current_store.url + '/orders/' + current_order.number%>",
     eventHandler: {
       onSuccess(payload) {
-        debugger
         var authenticity_token = $('input[name="authenticity_token"]')[0].value;
         // Call the backend API for verifying the token
         $.ajax({
@@ -26,6 +25,7 @@
           }
         }).done(function(response){
           console.log(response)
+          SpreeGatewaysNepal.showSaveAndContinue()
           // Successfully verified that the payment was successful
         })
       },

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,0 +1,58 @@
+this is khalti
+<a id="payment-button-khalti" href="#">Pay with Khalti</a>
+
+<script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
+
+<script>
+  window.addEventListener('DOMContentLoaded', function () {
+    SpreeGatewaysNepal.paymentMethodID = "<%= payment_method.id %>"
+  })
+  //
+  //{
+  //  "idx": "dJUHvrLBtucZ6sYK5BuNU5",
+  //"token": "hJ5HhSgLedDHSjYfKZaLNR",
+  //"amount": 1000,
+  //"mobile": "98XXXXX935",
+  //"product_identity": "1234567890",
+  //"product_name": "Drogon",
+  //"product_url": "http://gameofthrones.com/buy/Dragons"
+  //}
+
+  var config = {
+    // replace this key with yours
+    publicKey: 'test_public_key_5e19052f2a7e4b3bbf464a12653036bc',
+    productIdentity: '1234567890',
+    productName: 'Drogon',
+    productUrl: 'http://gameofthrones.com/buy/Dragons',
+    eventHandler: {
+      onSuccess(payload) {
+        // hit merchant api for initiating verfication
+        console.log(payload);
+      },
+      // onError handler is optional
+      onError(error) {
+        // handle errors
+        console.log(error);
+      },
+      onClose() {
+        console.log('widget is closing');
+      },
+    },
+    paymentPreference: [
+      'KHALTI',
+      'EBANKING',
+      'MOBILE_BANKING',
+      'CONNECT_IPS',
+      'SCT',
+    ],
+  };
+
+  var checkout = new KhaltiCheckout(config);
+  var btn = document.getElementById("payment-button-khalti");
+  btn.onclick = function (e) {
+    e.preventDefault();
+//    debugger
+    // minimum transaction amount must be 10, i.e 1000 in paisa.
+    checkout.show({amount: 1000});
+  }
+</script>

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,33 +1,28 @@
-this is khalti
 <a id="payment-button-khalti" href="#">Pay with Khalti</a>
-
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
-
+<% total_price = current_order.total%>
 <script>
   window.addEventListener('DOMContentLoaded', function () {
     SpreeGatewaysNepal.paymentMethodID = "<%= payment_method.id %>"
   })
-  //
-  //{
-  //  "idx": "dJUHvrLBtucZ6sYK5BuNU5",
-  //"token": "hJ5HhSgLedDHSjYfKZaLNR",
-  //"amount": 1000,
-  //"mobile": "98XXXXX935",
-  //"product_identity": "1234567890",
-  //"product_name": "Drogon",
-  //"product_url": "http://gameofthrones.com/buy/Dragons"
-  //}
 
   var config = {
     // replace this key with yours
-    publicKey: 'test_public_key_5e19052f2a7e4b3bbf464a12653036bc',
-    productIdentity: '1234567890',
-    productName: 'Drogon',
-    productUrl: 'http://gameofthrones.com/buy/Dragons',
+    publicKey: "<%= Spree::Gateway::Khalti.first.preferences[:test_public_key] %>",
+    productIdentity:"<%= current_order.name %>",
+    productName: "<%= current_order.products.first.name %>",
+    productUrl: "<%= 'localhost:3000/products/' + current_order.products.first.slug%>",
     eventHandler: {
       onSuccess(payload) {
-        // hit merchant api for initiating verfication
-        console.log(payload);
+        var authenticity_token = $('input[name="authenticity_token"]')[0].value;
+        // Call the backend API for verifying the token
+        $.ajax({
+          url: '/khalti',
+          type: 'POST',
+          data: payload + `authenticity_token=${token}`
+        }).done(function(response){
+          // Successfully verified that the payment was successful
+        })
       },
       // onError handler is optional
       onError(error) {
@@ -51,8 +46,6 @@ this is khalti
   var btn = document.getElementById("payment-button-khalti");
   btn.onclick = function (e) {
     e.preventDefault();
-//    debugger
-    // minimum transaction amount must be 10, i.e 1000 in paisa.
-    checkout.show({amount: 1000});
+    checkout.show({amount: "<%= current_order.total %>"});
   }
 </script>

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,4 +1,4 @@
-<a id="payment-button-khalti" href="#">Pay with Khalti</a>
+<a id="payment-button-khalti" href="#"><%= Spree.t(:pay_with_khalti) %></a>
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', function () {
@@ -23,9 +23,7 @@
             "authenticity_token": authenticity_token
           }
         }).done(function(response){
-          console.log(response)
           SpreeGatewaysNepal.showSaveAndContinue()
-          // Successfully verified that the payment was successful
         })
       },
       // onError handler is optional

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,5 +1,4 @@
 <a id="payment-button-khalti" href="#">Pay with Khalti</a>
-<% binding.pry %>
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', function () {

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -6,7 +6,7 @@
   })
 
   var config = {
-    publicKey: "<%= Spree::Gateway::Khalti.first.preferences[:test_public_key] %>",
+    publicKey: "<%= payment_method.preferences[:test_mode] ? payment_method.preferences[:test_public_key] :  payment_method.preferences[:live_public_key] %>",
     productIdentity:"<%= current_order.number %>",
     productName: "<%= current_order.number %>",
     productUrl: "<%= current_store.url + '/orders/' + current_order.number%>",
@@ -48,6 +48,6 @@
   var btn = document.getElementById("payment-button-khalti");
   btn.onclick = function (e) {
     e.preventDefault();
-    checkout.show({amount: "<%= (current_order.total.to_f) * 100 %>"});
+    checkout.show({amount: "<%= (current_order.total.to_f) * payment_method.paisa_rate %>"});
   }
 </script>

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,6 +1,5 @@
 <a id="payment-button-khalti" href="#">Pay with Khalti</a>
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
-<% total_price = current_order.total%>
 <script>
   window.addEventListener('DOMContentLoaded', function () {
     SpreeGatewaysNepal.paymentMethodID = "<%= payment_method.id %>"
@@ -11,16 +10,22 @@
     publicKey: "<%= Spree::Gateway::Khalti.first.preferences[:test_public_key] %>",
     productIdentity:"<%= current_order.name %>",
     productName: "<%= current_order.products.first.name %>",
-    productUrl: "<%= 'localhost:3000/products/' + current_order.products.first.slug%>",
+    productUrl: "<%= 'https://bazarnp.com/products/' + current_order.products.first.slug%>",
     eventHandler: {
       onSuccess(payload) {
+        debugger
         var authenticity_token = $('input[name="authenticity_token"]')[0].value;
         // Call the backend API for verifying the token
         $.ajax({
           url: '/khalti',
           type: 'POST',
-          data: payload + `authenticity_token=${token}`
+          data: {
+            "payload": payload,
+            "payment_method_id": "<%= payment_method.id%>",
+            "authenticity_token": authenticity_token
+          }
         }).done(function(response){
+          console.log(response)
           // Successfully verified that the payment was successful
         })
       },
@@ -46,6 +51,6 @@
   var btn = document.getElementById("payment-button-khalti");
   btn.onclick = function (e) {
     e.preventDefault();
-    checkout.show({amount: "<%= current_order.total %>"});
+    checkout.show({amount: "<%= (current_order.total.to_f) * 100 %>"});
   }
 </script>

--- a/app/views/spree/checkout/payment/_khalti.html.erb
+++ b/app/views/spree/checkout/payment/_khalti.html.erb
@@ -1,4 +1,5 @@
 <a id="payment-button-khalti" href="#">Pay with Khalti</a>
+<% binding.pry %>
 <script src="https://unpkg.com/khalti-checkout-web@latest/dist/khalti-checkout.iffe.js"></script>
 <script>
   window.addEventListener('DOMContentLoaded', function () {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,5 @@
 
 en:
   hello: "Hello world"
+  spree:
+    pay_with_khalti: "Pay With Khalti"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
   # Add your extension routes here
   post '/khalti', :to => "khalti#payment", :as => :khalti_payment
-  get '/khalti/payment-config', :to => "khalti#khalti_payment_config", :as => :khalti_payment_config, format: :json
+  get '/khalti/payment_config', :to => "khalti#khalti_payment_config", :as => :khalti_payment_config, format: :json
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Spree::Core::Engine.add_routes do
   # Add your extension routes here
+  post '/khalti', :to => "khalti#payment", :as => :khalti_payment
+  get '/khalti/payment-config', :to => "khalti#khalti_payment_config", :as => :khalti_payment_config, format: :json
 end

--- a/db/migrate/20200915153909_create_spree_khalti_checkouts.rb
+++ b/db/migrate/20200915153909_create_spree_khalti_checkouts.rb
@@ -1,0 +1,8 @@
+class CreateSpreeKhaltiCheckouts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :spree_khalti_checkouts do |t|
+      t.string :token
+      t.string :state
+    end
+  end
+end

--- a/db/migrate/20200915153909_create_spree_khalti_checkouts.rb
+++ b/db/migrate/20200915153909_create_spree_khalti_checkouts.rb
@@ -1,8 +1,0 @@
-class CreateSpreeKhaltiCheckouts < ActiveRecord::Migration[6.0]
-  def change
-    create_table :spree_khalti_checkouts do |t|
-      t.string :token
-      t.string :state
-    end
-  end
-end

--- a/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
+++ b/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
@@ -1,0 +1,13 @@
+class AddSpreeKhaltiPaymentSource < ActiveRecord::Migration[6.0]
+  def change
+    create_table :spree_khalti_payment_sources do |t|
+      t.string :payment_id
+      t.string :payment_method_name
+      t.string :issuer
+      t.string :status
+      t.string :payment_url
+      t.integer :payment_method_id
+      t.integer :user_id
+    end
+  end
+end

--- a/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
+++ b/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
@@ -20,7 +20,6 @@ class AddSpreeKhaltiPaymentSource < ActiveRecord::Migration[6.0]
       t.string :khalti_merchant_name
       t.string :khalti_merchant_email
       t.string :khalti_merchant_mobile
-      t.string :payment_id
       t.integer :payment_method_id
       t.integer :user_id
       t.timestamps

--- a/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
+++ b/db/migrate/20200921145856_add_spree_khalti_payment_source.rb
@@ -1,13 +1,29 @@
 class AddSpreeKhaltiPaymentSource < ActiveRecord::Migration[6.0]
   def change
     create_table :spree_khalti_payment_sources do |t|
+      t.string :khalti_payment_token_id
+      t.string :khalti_payment_type_id
+      t.string :khalti_payment_type_name
+      t.string :payment_state_id
+      t.string :payment_state_name
+      t.string :payment_state_template
+      t.float :amount
+      t.float :fee_amount
+      t.boolean :refunded
+      t.datetime :created_on
+      t.string :ebanker
+      t.string :khalti_user_id
+      t.string :khalti_user_name
+      t.string :khalti_user_email
+      t.string :khalti_user_mobile
+      t.string :khalti_merchant_id
+      t.string :khalti_merchant_name
+      t.string :khalti_merchant_email
+      t.string :khalti_merchant_mobile
       t.string :payment_id
-      t.string :payment_method_name
-      t.string :issuer
-      t.string :status
-      t.string :payment_url
       t.integer :payment_method_id
       t.integer :user_id
+      t.timestamps
     end
   end
 end

--- a/lib/generators/spree_gateways_nepal/install/install_generator.rb
+++ b/lib/generators/spree_gateways_nepal/install/install_generator.rb
@@ -4,8 +4,8 @@ module SpreeGatewaysNepal
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend\n"
+        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/spree_gateways_nepal\n"
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_gateways_nepal\n"
       end
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_gateways_nepal'

--- a/lib/generators/spree_gateways_nepal/install/install_generator.rb
+++ b/lib/generators/spree_gateways_nepal/install/install_generator.rb
@@ -5,7 +5,7 @@ module SpreeGatewaysNepal
 
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/spree_gateways_nepal\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_gateways_nepal\n"
+      #   append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_gateways_nepal\n"
       end
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_gateways_nepal'

--- a/lib/generators/spree_gateways_nepal/install/install_generator.rb
+++ b/lib/generators/spree_gateways_nepal/install/install_generator.rb
@@ -5,7 +5,6 @@ module SpreeGatewaysNepal
 
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/spree_gateways_nepal\n"
-      #   append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_gateways_nepal\n"
       end
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_gateways_nepal'

--- a/lib/generators/spree_gateways_nepal/install/install_generator.rb
+++ b/lib/generators/spree_gateways_nepal/install/install_generator.rb
@@ -3,6 +3,10 @@ module SpreeGatewaysNepal
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
 
+      def add_javascripts
+        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend\n"
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend\n"
+      end
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=spree_gateways_nepal'
       end

--- a/lib/spree_gateways_nepal/engine.rb
+++ b/lib/spree_gateways_nepal/engine.rb
@@ -4,6 +4,10 @@ module SpreeGatewaysNepal
     isolate_namespace Spree
     engine_name 'spree_gateways_nepal'
 
+    initializer "spree.gateway.payment_methods", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << Spree::Gateway::Khalti
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec


### PR DESCRIPTION
Implementation:
Done:
- [x] Server side verification of the khalti paymnet
- [x] Add the configuration params according to the test / live keys added to the backend
- [x] Add fields to add the test and live keys in the backend
- [x] Update install generator to include the js of spree_gateways_nepal

To Do:
- [x] Add the kalti payment as the payment source and allow submission of the checkout
- [x] Save the payment details (khalti token and payer information) to the DB
- [x] Usage of test / live keys according to the environment ( or the server / test_mode preferences of khalti payment)

Refactor tasks remaining
- [ ] Move the khalti API call to the khalti model instead of the controller
- [ ] Remove the API call for client side verification from the .erb file to js file